### PR TITLE
Remove gulp-util from dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
-var gutil = require('gulp-util');
-var PluginError = gutil.PluginError;
+var fancyLog = require('fancy-log');
+var PluginError = require('plugin-error');
+var replaceExt = require('replace-ext');
+var c = require('ansi-colors');
+var Vinyl = require('vinyl');
 var through = require('through2');
 var defaults = require('lodash.defaults');
 var parseCss = require('css-parse');
@@ -20,7 +23,7 @@ module.exports = function(options) {
   // Log info only when 'options.log' is set to true
   var log = function(message) {
     if (options.log) {
-      gutil.log(message);
+      fancyLog(message);
     }
   };
 
@@ -343,20 +346,20 @@ module.exports = function(options) {
 
     // Define the new file extension
     if (options.ext) {
-      file.path = gutil.replaceExtension(file.path, options.ext);
+      file.path = replaceExt(file.path, options.ext);
     }
 
     // Write the new file
     file.contents = new Buffer(strStyles);
-    log(gutil.colors.cyan('File ' + filename + ' created.'));
+    log(c.cyan('File ' + filename + ' created.'));
 
     if (options.use_external && processedCSS.media.length !== 0) {
-      var f = new gutil.File({
+      var f = new Vinyl({
         base: file.base,
         path: extFilename,
         contents: new Buffer(strMediaStyles)
       });
-      log(gutil.colors.cyan('File ' + extFilename + ' created.'));
+      log(c.cyan('File ' + extFilename + ' created.'));
     }
     this.push(file);
     if (options.use_external && processedCSS.media.length !== 0) {

--- a/package.json
+++ b/package.json
@@ -22,9 +22,13 @@
   },
   "dependencies": {
     "css-parse": "~1.7.0",
+    "fancy-log": "^1.3.2",
+    "plugin-error": "^1.0.1",
+    "replace-ext": "^1.0.0",
+    "ansi-colors": "^3.0.3",
+    "vinyl": "^2.2.0",
     "lodash.defaults": "~2.4.1",
-    "through2": "~0.4.1",
-    "gulp-util": "~2.2.14"
+    "through2": "~0.4.1"
   },
   "licenses": [
     {


### PR DESCRIPTION
`gulp-util` is depreciated so I have removed it from dependencies and replaces with other dependencies from this post: https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5